### PR TITLE
fix: libbyond dlopen flags for linux

### DIFF
--- a/prof.c
+++ b/prof.c
@@ -1303,7 +1303,7 @@ char *UTRACY_WINDOWS_CDECL UTRACY_LINUX_CDECL init(int argc, char **argv) {
 	}
 
 #elif defined(UTRACY_LINUX)
-	struct link_map *libbyond = dlopen("libbyond.so", RTLD_NOLOAD);
+	struct link_map *libbyond = dlopen("libbyond.so", RTLD_NOW | RTLD_NOLOAD);
 	if(NULL == libbyond) {
 		LOG_DEBUG_ERROR;
 		return "unable to find base address of libbyond.so";


### PR DESCRIPTION
I was experiencing an issue with the byond-tracy library without `RTLD_NOW` flag. I compiled the lib on Ubuntu and was trying to get it to work thinking "What am I doing wrong? Why can't it find Byond's own library even though the path is defined in LD_LIBRARY_PATH?"
```
ExecStart=/bin/bash -c "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/lib/byond/byond514.1588/bin exec /var/lib/byond/byond514.1588/bin/DreamDaemon baystation12.dmb 7777 -trusted -invisible"
```

```
libprof.so init error: unable to find base address of libbyond.so 
```

jreaper suggested a fix and it worked
![image](https://github.com/ParadiseSS13/byond-tracy/assets/8555356/d288a219-3ad8-458d-a252-e67409350a60)
