### PR TITLE
init() now returns the output filename

### DIFF
--- a/prof.c
+++ b/prof.c
@@ -1472,7 +1472,8 @@ char *UTRACY_WINDOWS_CDECL UTRACY_LINUX_CDECL init(int argc, char **argv) {
 #define MAX_PATH 260 // same as windows
 #endif
 
-	char ffilename[MAX_PATH];
+	static char ffilename[MAX_PATH];
+	*ffilename = 0;
 	snprintf(ffilename, MAX_PATH, "./data/profiler/%llu.utracy", utracy_tsc());
 	utracy.fstream = fopen(ffilename, "wb");
 	if(NULL == utracy.fstream) {
@@ -1504,7 +1505,7 @@ char *UTRACY_WINDOWS_CDECL UTRACY_LINUX_CDECL init(int argc, char **argv) {
 #endif
 
 	initialized = 1;
-	return "0";
+	return ffilename;
 }
 
 UTRACY_EXTERNAL

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,10 @@ None built in, you need to reply these.
 
 simply call `init` from `prof.dll` to begin writing to a file inside `data/profiler`
 
+init will return the filename it writes to upon success - the filename will always start with `.`
+
 ```dm
+// returns a string filename whenever
 /proc/prof_init()
     var/lib
 
@@ -82,10 +85,13 @@ simply call `init` from `prof.dll` to begin writing to a file inside `data/profi
         else CRASH("unsupported platform")
 
     var/init = call_ext(lib, "init")()
-    if("0" != init) CRASH("[lib] init error: [init]")
+    if(length(init) != 0 && init[1] == ".") // if first character is ., then it returned the output filename
+        return init
+    else if("0" != init)
+        CRASH("[lib] init error: [init]")
 
 /world/New()
-    prof_init()
+    var/utracy_filename = prof_init()
     . = ..()
 ```
 


### PR DESCRIPTION
# THIS IS A BREAKING CHANGE

Simple, `init()` now returns the output filename, rather than just "0"

this way, you can easily associate a specific utracy file with a round id

example for DM-side changes, implemented on MonkeStation (code should easily carry over to most modern codebases that use /world/Genesis, tho). simply outputs the file loc to `[GLOB.log_directory]/tracy.loc`.
DM side is backwards compatible with versions of tracy that just return "0", however tracy is _not_ backwards compatible after this change

```diff
diff --git c/code/game/world.dm w/code/game/world.dm
index 6a071e02ef8..a5263ef1603 100644
--- c/code/game/world.dm
+++ w/code/game/world.dm
@@ -6,6 +6,9 @@
 #define NO_INIT_PARAMETER "no-init"
 
 GLOBAL_VAR(restart_counter)
+#ifdef USE_BYOND_TRACY
+GLOBAL_VAR(tracy_log)
+#endif
 
 /**
  * WORLD INITIALIZATION
@@ -62,7 +65,9 @@ GLOBAL_VAR(restart_counter)
 #ifdef USE_BYOND_TRACY
 #warn USE_BYOND_TRACY is enabled
 	if(!tracy_initialized)
-		init_byond_tracy()
+		GLOB.tracy_log = init_byond_tracy()
+		if(GLOB.tracy_log)
+			world.log << "Tracy profile log located at [GLOB.tracy_log]"
 		Genesis(tracy_initialized = TRUE)
 		return
 #endif
@@ -216,6 +221,11 @@ GLOBAL_VAR(restart_counter)
 	GLOB.demo_log = "[GLOB.demo_directory]/[GLOB.round_id]_demo.txt" //Guh //Monkestation Edit: REPLAYS
 	logger.init_logging()
 
+#ifdef USE_BYOND_TRACY
+	if(GLOB.tracy_log)
+		rustg_file_write("[GLOB.tracy_log]", "[GLOB.log_directory]/tracy.loc")
+#endif
+
 	var/latest_changelog = file("[global.config.directory]/../html/changelogs/archive/" + time2text(world.timeofday, "YYYY-MM") + ".yml")
 	GLOB.changelog_hash = fexists(latest_changelog) ? md5(latest_changelog) : 0 //for telling if the changelog has changed recently
 
@@ -475,7 +485,9 @@ GLOBAL_VAR(restart_counter)
 			CRASH("Unsupported platform: [system_type]")
 
 	var/init_result = call_ext(library, "init")("block")
-	if (init_result != "0")
+	if(length(init_result) != 0 && init_result[1] == ".") // if first character is ., then it returned the output filename
+		return init_result
+	else if(init_result != "0")
 		CRASH("Error initializing byond-tracy: [init_result]")
 
 /world/proc/init_debugger()
```

yes i tested this